### PR TITLE
Create KVM-OpenCore-Sequoia

### DIFF
--- a/KVM-OpenCore-Sequoia
+++ b/KVM-OpenCore-Sequoia
@@ -1,0 +1,1 @@
+I made changes and done a fork of the KVM OpenCore, in order to make it work Apple Services with macOS Sequoia.


### PR DESCRIPTION
In this change I integrated the patches that enables Apple Services at macOS Sequoia running through a Proxmox VM.  It patches the kernel with config.plist.      And with this one, no needs to jump iCloud setting when you are installing the Operating System

Just patching the Config.plist file with OpenConfigurator as follows:


Identifier: kernel, Count: 1,  Find: 68696265726E61746568696472656164790068696265726E617465636F756E7400  Limit: 0,  Replace: 68696265726E61746568696472656164790068765F766D6D5F70726573656E7400 Skip: 0 Arch: x86_64

Identifier: kernel, Count: 1,  Find: 626F6F742073657373696F6E20555549440068765F766D6D5F70726573656E7400 Limit: 0, Replace: 626F6F742073657373696F6E20555549440068696265726E617465636F756E7400  Skip: 0 Arch: x86_64
